### PR TITLE
fix: Delay tab key by 1 frame

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,11 @@ const tabSequence = require('ally.js/query/tabsequence')
 
 const { _, Promise } = Cypress
 
+const raf = () =>
+  new Cypress.Promise(resolve => {
+    cy.state('window').requestAnimationFrame(resolve);
+  });
+
 Cypress.Commands.add('tab', { prevSubject: 'optional' }, (subject, opts = {}) => {
 
   const options = _.defaults({}, opts, {
@@ -63,11 +68,13 @@ const performTab = (el, options) => {
     // return newElm
   }
 
-  return Promise.try(() => {
-    return keydown(activeElement, options, simulatedDefault, _.noop)
-  }).finally(() => {
-    keyup(activeElement, options)
-  })
+  return raf().then(() => {
+    return Promise.try(() => {
+      return keydown(activeElement, options, simulatedDefault, simulatedCancel);
+    }).finally(() => {
+      keyup(activeElement, options);
+    });
+  });
 
 }
 


### PR DESCRIPTION
Some applications may modify the DOM in response to `blur` and `focus` events. This change allows the DOM to be updated before the tab is performed. If `cy.tab` is chained together, the DOM is allowed to be updated between tab key events. This also allows the video to capture focus changes.

Fixes #4

Feel free to close this if you want a different solutions