### PR TITLE
fix: Optional previous element subject

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ const tabSequence = require('ally.js/query/tabsequence')
 
 const { _, Promise } = Cypress
 
-Cypress.Commands.add('tab', { prevSubject: 'optional' }, (subject, opts = {}) => {
+Cypress.Commands.add('tab', { prevSubject: ['optional', 'element'] }, (subject, opts = {}) => {
 
   const options = _.defaults({}, opts, {
     shift: false,


### PR DESCRIPTION
This fix is small, but removed the error of `Cannot read property 'ownerDocument' of undefined`. This change will change the error to be the built-in Cypress error stating the previous subject must be an element (if supplied). It will then output the subject and previously run command.