### PR TITLE
fix: Off by one error in next/previous tab

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,4 +23,7 @@
       "autoFix": true
     },
   ],
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
 }

--- a/circle.yml
+++ b/circle.yml
@@ -20,6 +20,8 @@ jobs:
     - run:
         command: yarn test-e2e
     - run:
+        command: yarn add -D cypress@3.4.1 && yarn test-e2e
+    - run:
         command: yarn run semantic-release
 workflows:
   build:

--- a/cypress/integration/spec.js
+++ b/cypress/integration/spec.js
@@ -1,5 +1,4 @@
 /// <reference types="cypress"/>
-/* global cy */
 
 // const { _ } = Cypress
 

--- a/cypress/integration/spec.js
+++ b/cypress/integration/spec.js
@@ -1,4 +1,5 @@
 /// <reference types="cypress"/>
+/* global cy */
 
 // const { _ } = Cypress
 
@@ -91,6 +92,16 @@ describe('form test', () => {
     cy.get('body').tab().tab().tab().then(beFocused)
 
     cy.get('body').should(beFocused)
+  })
+
+  it('moves focus back to the first element when the last element is focused', () => {
+    cy.get('a:last').tab()
+    cy.get('a:first').should(beFocused)
+  })
+
+  it('moves focus back to the first element when the last element is focused', () => {
+    cy.get('a:first').tab({ shift: true })
+    cy.get('a:last').should(beFocused)
   })
 
   describe('events', () => {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@cypress/eslint-plugin-dev": "^4.0.0",
     "@typescript-eslint/eslint-plugin": "^2.3.0",
     "@typescript-eslint/parser": "^2.3.0",
-    "cypress": "^3.4.1",
+    "cypress": "^3.8.0",
     "eslint": "^6.4.0",
     "eslint-plugin-cypress": "^2.2.1",
     "eslint-plugin-json-format": "^2.0.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+/* global Cypress, cy */
 const tabSequence = require('ally.js/query/tabsequence')
 
 const { _, Promise } = Cypress
@@ -75,22 +76,14 @@ const performTab = (el, options) => {
 
 const nextItemFromIndex = (i, seq, reverse) => {
   if (reverse) {
-    if (i === 0 || i === -1) {
-      i = seq.length
-    }
-  } else {
-    if (i === seq.length) {
-      i = 0
-    }
+    const nextIndex = i <= 0 ? seq.length - 1 : i - 1
 
-  }
-  // }
-
-  if (reverse) {
-    return seq[i - 1]
+    return seq[nextIndex]
   }
 
-  return seq[i + 1]
+  const nextIndex = i === seq.length - 1 ? 0 : i + 1
+
+  return seq[nextIndex]
 }
 
 const tabKeyEventPartial = {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-/* global Cypress, cy */
 const tabSequence = require('ally.js/query/tabsequence')
 
 const { _, Promise } = Cypress

--- a/yarn.lock
+++ b/yarn.lock
@@ -246,6 +246,11 @@
   resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
   integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
 
+"@types/sizzle@2.3.2":
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/@types/sizzle/-/sizzle-2.3.2.tgz#a811b8c18e2babab7d542b3365887ae2e4d9de47"
+  integrity sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==
+
 "@typescript-eslint/eslint-plugin@^2.3.0":
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.3.0.tgz#6ead12c6b15a9b930430931e396e01a1fe181fcc"
@@ -1118,13 +1123,14 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
-cypress@^3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-3.4.1.tgz#ca2e4e9864679da686c6a6189603efd409664c30"
-  integrity sha512-1HBS7t9XXzkt6QHbwfirWYty8vzxNMawGj1yI+Fu6C3/VZJ8UtUngMW6layqwYZzLTZV8tiDpdCNBypn78V4Dg==
+cypress@^3.8.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-3.8.0.tgz#7d4cd08f81f9048ee36760cc9ee3b9014f9e84ab"
+  integrity sha512-gtEbqCgKETRc3pQFMsELRgIBNgiQg7vbOWTrCi7WE7bgOwNCaW9PEX8Jb3UN8z/maIp9WwzoFfeySfelYY7nRA==
   dependencies:
     "@cypress/listr-verbose-renderer" "0.4.1"
     "@cypress/xvfb" "1.2.4"
+    "@types/sizzle" "2.3.2"
     arch "2.1.1"
     bluebird "3.5.0"
     cachedir "1.3.0"
@@ -1151,6 +1157,7 @@ cypress@^3.4.1:
     request-progress "3.0.0"
     supports-color "5.5.0"
     tmp "0.1.0"
+    untildify "3.0.3"
     url "0.11.0"
     yauzl "2.10.0"
 
@@ -5527,6 +5534,11 @@ unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
   integrity sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
+
+untildify@3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/untildify/-/untildify-3.0.3.tgz#1e7b42b140bcfd922b22e70ca1265bfe3634c7c9"
+  integrity sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA==
 
 unzip-response@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
* Fixes #13

This change fixes the edge cases when using shift-tab when on the first focusable element and the edge case when using tab when on the last focusable element. The error was "Cannot call select of undefined"