### PR TITLE
fix: allow tabbing out of [tabindex=-1] elements

### DIFF
--- a/cypress/fixtures/tabindex.html
+++ b/cypress/fixtures/tabindex.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>cy.tab Focusable Test</title>
+</head>
+<body>
+  <a href="#title" id="skipLink">Skip to main content</a>
+  
+  <main>
+    <h1 id="title" tabindex="-1">Page title</h1>
+
+    <h2 id="subtitle">Page subtitle</h2>
+
+    <p>Lorem, ipsum dolor sit amet consectetur adipisicing elit. Illum ratione minima voluptate consequuntur autem temporibus reprehenderit. Nisi, odit nobis ab quis vitae et! Dignissimos facilis commodi mollitia vitae iusto quo.</p>
+
+    <p>Lorem, ipsum dolor sit amet consectetur adipisicing elit. <a id="contentLink" href="#">Suscipit distinctio mollitia</a> ut maiores pariatur excepturi officiis natus sequi illo libero.</p>
+  </main>
+  
+</body>
+</html>

--- a/cypress/integration/spec.js
+++ b/cypress/integration/spec.js
@@ -2,7 +2,58 @@
 
 // const { _ } = Cypress
 
-describe('form test', () => {
+describe('tabindex -1 test', () => {
+  beforeEach(() => {
+    cy.visit('/cypress/fixtures/tabindex.html')
+  });
+
+  describe('Move focus away from tabindex -1 element', () => {
+    beforeEach(() => {
+      cy.get('#title')
+        .focus()
+        .should('have.focus');
+    });
+
+    it('Should focus content link after tab', () => {
+      cy.focused().tab();
+
+      cy.get('#contentLink')
+        .should('have.focus');
+    });
+
+    it('Should focus skip link before tab', () => {
+      cy.focused().tab({ shift: true });
+
+      cy.get('#skipLink')
+        .should('have.focus');
+    });
+  });
+
+  describe('Tab should skip -1 element', () => {
+    it('Follows expected tab order', () => {
+      cy.get('body')
+        .tab();
+  
+      cy.get('#skipLink')
+        .should('have.focus');
+  
+      cy.focused().tab();
+  
+      cy.get('#contentLink')
+        .should('have.focus');
+    });
+  });
+
+  describe('Focus a non-focusable element', () => {
+    it('Should return an error message', () => {
+      cy.get('#subtitle').focus();
+
+      cy.focused().tab();
+    })
+  })
+})
+
+describe.skip('form test', () => {
 
   beforeEach(() => {
     cy.visit('/cypress/fixtures/forms.html')

--- a/src/index.js
+++ b/src/index.js
@@ -27,14 +27,21 @@ const performTab = (el, options) => {
   const doc = el.ownerDocument
   const activeElement = doc.activeElement
 
-  const seq = tabSequence({
+  const isFocusable = focusable({
+    strategy: 'quick',
+    includeContext: false,
+    includeOnlyTabbable: false,
+    context: doc.documentElement,
+  })
+
+  const isTabbable = tabSequence({
     strategy: 'quick',
     includeContext: false,
     includeOnlyTabbable: true,
     context: doc.documentElement,
   })
 
-  let index = seq.indexOf(el)
+  let index = isFocusable.indexOf(el)
 
   if (index === -1) {
     if (el && !(el === doc.body)) {
@@ -46,12 +53,12 @@ const performTab = (el, options) => {
     }
   }
 
-  debug(seq, index)
+  debug(isFocusable, index)
 
   /**
    * @type {HTMLElement}
    */
-  const newElm = nextItemFromIndex(index, seq, options.shift)
+  const newElm = nextItemFromIndex(index, isTabbable, options.shift)
 
   const simulatedDefault = () => {
     if (newElm.select) {
@@ -74,16 +81,14 @@ const performTab = (el, options) => {
 
 }
 
-const nextItemFromIndex = (i, seq, reverse) => {
+const nextItemFromIndex = (i, isTabbable, reverse) => {
   if (reverse) {
-    const nextIndex = i <= 0 ? seq.length - 1 : i - 1
-
-    return seq[nextIndex]
+    const nextIndex = i <= 0 ? isTabbable.length - 1 : i - 1
+    return isTabbable[nextIndex]
   }
 
-  const nextIndex = i === seq.length - 1 ? 0 : i + 1
-
-  return seq[nextIndex]
+  const nextIndex = i === isTabbable.length - 1 ? 0 : i + 1
+  return isTabbable[nextIndex]
 }
 
 const tabKeyEventPartial = {

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+const focusable = require('ally.js/query/focusable');
 const tabSequence = require('ally.js/query/tabsequence')
 
 const { _, Promise } = Cypress


### PR DESCRIPTION
# Description

> Definitely just a draft but wanted to get my changes in the hands of the maintainers and others if interest arises to assist in resolving this.

Currently the plugin will error if you focus a _focusable_, `tabindex=-1` element and try to tab out of it. This is incorrect as long as the element is capable of being focused programmatically, which -1 is.

## **Solutions**:

@Bkucera suggested moving from ally.js to tabbable.js but ally.js does include a differentiation query between focusable and tabbable. The changes here allow tabbing out of focusable elements (but will still error if trying to tab from non-focusable elements).

## **WIP**:

Focusing on a -1 element and pressing tab currently goes backwards. I believe this has to do with how the index traversal was setup based on isTabbable and needs to be updated to work based on the _next_ item in the isTabbable tree based on the current isFocusable item.

I'll keep trying things but JS isn't my top language by any means so I definitely welcome help from anyone.

This PR includes a separate HTML in fixtures with a simplified setup, as well a series of rudimentary tests on the fixture. Note that it also adds a skip to the plugins original spec files to speed up the testing flow for this issue and it should be reverted prior to merging (potentially in addition to removing the new HTML/spec files).