### PR TITLE
feat: add `strategy` option for ally.js tabsequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ require('cypress-plugin-tab')
 - `.tab()` must be chained off of a tabbable(focusable) subject, or the `body`
 - `.tab()` changes the subject to the newly focused element after pressing `tab`
 - `.tab({ shift: true })` sends a shift-tab to the element
+- `.tab({ strategy: 'strict' })` uses the [ally.js `strict` strategy](https://allyjs.io/api/query/focusable.html#description) when finding tabbable elements, including Shadow DOM elements
 
 ```js
   cy.get('input').type('foo').tab().type('bar') // type foo, then press tab, then type bar
@@ -48,6 +49,19 @@ cy.get('input')
   .type('foop').tab()
   .type('bar').tab({ shift: true })
   .type('foo') // correct your mistake
+```
+
+Shadow DOM elements:
+
+```js
+// example: Ionic apps
+cy.get('ion-page').tab({ strategy: 'strict' });
+
+// example: always use strict by default for Shadow DOM-enabled apps
+// in commands.js
+Cypress.Commands.overwrite('tab', (originalFn, opts) => {
+  return originalFn({ strategy: 'strict', ...opts });
+})
 ```
 
 ### License

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,7 +1,28 @@
 /// <reference types="cypress" />
 
 declare namespace Cypress {
-	interface Chainable {
-		tab(options?: Partial<{shift: Boolean}>): Chainable
-	}
+  interface TabCommandOptions {
+    /**
+     * Whether or not to use the Shift+Tab modifier
+     */
+    shift?: boolean
+
+    /**
+     * Ally.js focusable strategy to use.
+     *
+     * `quick` - (default) The "quick" strategy uses `document.querySelectorAll` and is able to
+     *  find most focusable elements. Elements that are made focusable by way of CSS
+     *  properties cannot be queried that way, though.
+     *
+     * `strict` - The "strict" strategy makes use of `TreeWalker` to "manually" iterate over the DOM. It is slower than "quick".
+     *
+     * `all` - The "all" strategy will find all the elements that are either focus relevant or only tabbable - including
+     *  elements that would be focusable, were they not visually hidden or disabled.
+     */
+    strategy?: 'quick' | 'strict' | 'all'
+  }
+
+  interface Chainable {
+    tab(options?: Partial<TabCommandOptions>): Chainable
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ Cypress.Commands.add('tab', { prevSubject: ['optional', 'element'] }, (subject, 
 
   const options = _.defaults({}, opts, {
     shift: false,
+    strategy: 'quick',
   })
 
   debug('subject:', subject)
@@ -27,7 +28,7 @@ const performTab = (el, options) => {
   const activeElement = doc.activeElement
 
   const seq = tabSequence({
-    strategy: 'quick',
+    strategy: options.strategy,
     includeContext: false,
     includeOnlyTabbable: true,
     context: doc.documentElement,


### PR DESCRIPTION
Closes #25 

## Changes

- Add `strategy` option with `quick` as the default
- Add declarations with JSDocs
- Add README docs for `strategy` option

## Proposal

Pass-through `strategy` option to `ally.js/query/tabsequence` command, with `quick` as the default.

```js
cy.get("body").tab({ strategy: 'strict' });
```

## Alternative

You could instead make this more usage-centric and open to further changes to how the logic works by instead having a `includeShadowDom` option, which for now would just set the strategy to `strict` internally. This matches the same option Cypress uses for `cy.get` experiment: https://docs.cypress.io/guides/references/experiments.html#includeShadowDom

```js
cy.get("body").tab({ includeShadowDom: true });
```